### PR TITLE
Pass along basic auth credentials

### DIFF
--- a/prom-revisionist.go
+++ b/prom-revisionist.go
@@ -137,6 +137,11 @@ func main() {
 		}
 		proxyReq.Header = req.Header
 
+		username, password, ok := req.BasicAuth()
+		if ok {
+			proxyReq.SetBasicAuth(username, password)
+		}
+
 		resp, err := http.DefaultClient.Do(proxyReq)
 		if err != nil {
 			log.Printf("failed to created request: %s", err)
@@ -240,6 +245,11 @@ func main() {
 			return
 		}
 		proxyReq.Header = req.Header
+
+		username, password, ok := req.BasicAuth()
+		if ok {
+			proxyReq.SetBasicAuth(username, password)
+		}
 
 		resp, err := http.DefaultClient.Do(proxyReq)
 		if err != nil {


### PR DESCRIPTION
Some Prometheus/Thanos/... instances might need it, so let's support it.  See https://prometheus.io/docs/prometheus/latest/configuration/https/#https-and-authentication for some details.